### PR TITLE
fix portal navigation 404s

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -19,7 +19,11 @@ import NotFound from "./pages/not-found";
 function PortalRedirect() {
   const [, setLocation] = useLocation();
   useEffect(() => {
-    setLocation('/portal/dashboard');
+    // When navigating within the nested portal router, paths are relative to
+    // the "/portal" base. Using an absolute path here would prepend another
+    // "/portal" segment resulting in a 404 (e.g. "/portal/portal/dashboard").
+    // Redirect directly to the dashboard using a relative path instead.
+    setLocation('/dashboard');
   }, [setLocation]);
   return null;
 }

--- a/client/src/components/layout/portal-header.tsx
+++ b/client/src/components/layout/portal-header.tsx
@@ -11,7 +11,9 @@ export function PortalHeader() {
   const [, setLocation] = useLocation();
 
   const handleProfileSettings = () => {
-    setLocation('/portal/profile');
+    // use a path relative to the "/portal" base to avoid duplicating it
+    // ("/portal/profile" -> "/portal/portal/profile")
+    setLocation('/profile');
   };
 
   const handleLogout = () => {

--- a/client/src/components/layout/portal-sidebar.tsx
+++ b/client/src/components/layout/portal-sidebar.tsx
@@ -9,11 +9,14 @@ import {
 } from "lucide-react";
 
 const navigation = [
-  { name: 'Dashboard', href: '/portal/dashboard', icon: BarChart3 },
-  { name: 'Contribute Knowledge', href: '/portal/contribute', icon: PlusCircle },
-  { name: 'My Knowledge Status', href: '/portal/status', icon: CheckSquare },
-  { name: 'Earnings', href: '/portal/earnings', icon: TrendingUp },
-  { name: 'Support', href: '/portal/support', icon: LifeBuoy },
+  // the sidebar lives inside a router with base "/portal", so links should be
+  // relative to that base. Prefixing them with "/portal" again would produce
+  // URLs like "/portal/portal/dashboard" which fall through to the 404 page.
+  { name: 'Dashboard', href: '/dashboard', icon: BarChart3 },
+  { name: 'Contribute Knowledge', href: '/contribute', icon: PlusCircle },
+  { name: 'My Knowledge Status', href: '/status', icon: CheckSquare },
+  { name: 'Earnings', href: '/earnings', icon: TrendingUp },
+  { name: 'Support', href: '/support', icon: LifeBuoy },
 ];
 
 export function PortalSidebar() {

--- a/client/src/pages/portal/dashboard.tsx
+++ b/client/src/pages/portal/dashboard.tsx
@@ -97,11 +97,12 @@ export default function Dashboard() {
   const userName = getUserName();
 
   const handleContributeKnowledge = () => {
-    setLocation('/portal/contribute');
+    // navigate using a path relative to the portal base
+    setLocation('/contribute');
   };
 
   const handleReviewFeedback = () => {
-    setLocation('/portal/status');
+    setLocation('/status');
   };
 
   return (

--- a/client/src/pages/portal/portal-layout.tsx
+++ b/client/src/pages/portal/portal-layout.tsx
@@ -15,7 +15,10 @@ export default function PortalLayout({ children }: PortalLayoutProps) {
   // Redirect if not approved
   useEffect(() => {
     if (!approval.approved) {
-      setLocation('/join');
+      // Escape the portal router's base when redirecting to the onboarding
+      // flow. Using a relative path would result in "/portal/join" which doesn't
+      // exist and would show a 404 page.
+      setLocation('~/join');
     }
   }, [approval.approved, setLocation]);
 


### PR DESCRIPTION
## Summary
- avoid double `/portal` segments by using relative paths in portal navigation
- ensure unapproved users redirect outside portal base

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_b_689b28c2b530832fa716ba278e0ccb66