### PR TITLE
Fix portal navigation paths to prevent 404 errors

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -19,7 +19,8 @@ import NotFound from "./pages/not-found";
 function PortalRedirect() {
   const [, setLocation] = useLocation();
   useEffect(() => {
-    setLocation('/portal/dashboard');
+    // Navigate to the dashboard using a path relative to /portal
+    setLocation('/dashboard');
   }, [setLocation]);
   return null;
 }

--- a/client/src/components/layout/portal-header.tsx
+++ b/client/src/components/layout/portal-header.tsx
@@ -11,7 +11,8 @@ export function PortalHeader() {
   const [, setLocation] = useLocation();
 
   const handleProfileSettings = () => {
-    setLocation('/portal/profile');
+    // Navigate relative to the portal base to avoid duplicating the path
+    setLocation('/profile');
   };
 
   const handleLogout = () => {

--- a/client/src/components/layout/portal-sidebar.tsx
+++ b/client/src/components/layout/portal-sidebar.tsx
@@ -8,12 +8,13 @@ import {
   LifeBuoy
 } from "lucide-react";
 
+// Use routes relative to the portal base so navigation works with nested routing
 const navigation = [
-  { name: 'Dashboard', href: '/portal/dashboard', icon: BarChart3 },
-  { name: 'Contribute Knowledge', href: '/portal/contribute', icon: PlusCircle },
-  { name: 'My Knowledge Status', href: '/portal/status', icon: CheckSquare },
-  { name: 'Earnings', href: '/portal/earnings', icon: TrendingUp },
-  { name: 'Support', href: '/portal/support', icon: LifeBuoy },
+  { name: 'Dashboard', href: '/dashboard', icon: BarChart3 },
+  { name: 'Contribute Knowledge', href: '/contribute', icon: PlusCircle },
+  { name: 'My Knowledge Status', href: '/status', icon: CheckSquare },
+  { name: 'Earnings', href: '/earnings', icon: TrendingUp },
+  { name: 'Support', href: '/support', icon: LifeBuoy },
 ];
 
 export function PortalSidebar() {

--- a/client/src/pages/portal/dashboard.tsx
+++ b/client/src/pages/portal/dashboard.tsx
@@ -97,11 +97,12 @@ export default function Dashboard() {
   const userName = getUserName();
 
   const handleContributeKnowledge = () => {
-    setLocation('/portal/contribute');
+    // Use relative paths within the portal router
+    setLocation('/contribute');
   };
 
   const handleReviewFeedback = () => {
-    setLocation('/portal/status');
+    setLocation('/status');
   };
 
   return (


### PR DESCRIPTION
## Summary
- fix portal redirects and navigation to use paths relative to `/portal`
- update header and dashboard links to avoid duplicated `/portal`

## Testing
- `npm run check`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_689b23635398832fb1196cb20ee287c9