### PR TITLE
Align expert portal theme with landing page

### DIFF
--- a/client/src/components/layout/portal-header.tsx
+++ b/client/src/components/layout/portal-header.tsx
@@ -30,18 +30,18 @@ export function PortalHeader() {
   };
 
   return (
-    <header className="bg-white border-b border-gray-200 shadow-sm" data-testid="portal-header">
+    <header className="bg-bg-dark border-b border-border-dark shadow-sm" data-testid="portal-header">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex justify-between items-center h-16">
           <div className="flex items-center">
-            <span className="text-xl font-bold text-gray-900">Expert Knowledge Portal</span>
+            <span className="text-xl font-bold text-white">Expert Knowledge Portal</span>
           </div>
-          
+
           <div className="flex items-center space-x-4">
-            <Button variant="ghost" size="sm" className="text-gray-500 hover:text-gray-900" data-testid="notifications-button">
+            <Button variant="ghost" size="sm" className="text-text-muted hover:text-white" data-testid="notifications-button">
               <Bell className="h-5 w-5" />
             </Button>
-            
+
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <Button variant="ghost" className="flex items-center space-x-3" data-testid="user-menu-trigger">
@@ -50,19 +50,19 @@ export function PortalHeader() {
                       {getInitials(auth.user.name)}
                     </AvatarFallback>
                   </Avatar>
-                  <span className="font-medium text-gray-900" data-testid="user-name">
+                  <span className="font-medium text-white" data-testid="user-name">
                     Hi, {auth.user.name}
                   </span>
-                  <ChevronDown className="h-4 w-4 text-gray-500" />
+                  <ChevronDown className="h-4 w-4 text-text-muted" />
                 </Button>
               </DropdownMenuTrigger>
-              
-              <DropdownMenuContent align="end" className="w-48" data-testid="user-menu">
-                <DropdownMenuItem onClick={handleProfileSettings} data-testid="menu-profile-settings">
+
+              <DropdownMenuContent align="end" className="w-48 bg-card-dark border-border-dark text-white" data-testid="user-menu">
+                <DropdownMenuItem className="focus:bg-bg-dark focus:text-white" onClick={handleProfileSettings} data-testid="menu-profile-settings">
                   <Settings className="mr-2 h-4 w-4" />
                   Profile Settings
                 </DropdownMenuItem>
-                <DropdownMenuItem onClick={handleLogout} data-testid="menu-logout">
+                <DropdownMenuItem className="focus:bg-bg-dark focus:text-white" onClick={handleLogout} data-testid="menu-logout">
                   <LogOut className="mr-2 h-4 w-4" />
                   Logout
                 </DropdownMenuItem>

--- a/client/src/components/layout/portal-sidebar.tsx
+++ b/client/src/components/layout/portal-sidebar.tsx
@@ -23,21 +23,21 @@ export function PortalSidebar() {
   const [location, setLocation] = useLocation();
 
   return (
-    <aside className="w-64 bg-white border-r border-gray-200 min-h-screen" data-testid="portal-sidebar">
+    <aside className="w-64 bg-card-dark border-r border-border-dark text-white min-h-screen" data-testid="portal-sidebar">
       <nav className="p-4 space-y-2">
         {navigation.map((item) => {
           const Icon = item.icon;
           const isActive = location === item.href;
-          
+
           return (
             <button
               key={item.name}
               onClick={() => setLocation(item.href)}
               className={cn(
                 "w-full flex items-center px-4 py-3 text-left rounded-xl transition-smooth",
-                isActive 
-                  ? "bg-primary text-white" 
-                  : "text-gray-600 hover:bg-gray-100 hover:text-gray-900"
+                isActive
+                  ? "bg-primary text-white"
+                  : "text-text-muted hover:bg-bg-dark hover:text-white"
               )}
               data-testid={`nav-${item.name.toLowerCase().replace(/\s+/g, '-')}`}
             >

--- a/client/src/pages/portal/dashboard.tsx
+++ b/client/src/pages/portal/dashboard.tsx
@@ -106,11 +106,11 @@ export default function Dashboard() {
   };
 
   return (
-    <div className="space-y-6" data-testid="dashboard-page">
+    <div className="space-y-6 text-white" data-testid="dashboard-page">
       {/* Welcome Header */}
       <div className="mb-8">
-        <h1 className="text-4xl font-bold text-gray-900 mb-2">Welcome, {userName}!</h1>
-        <p className="text-gray-600 text-lg">Here's an overview of your expert activity and contributions.</p>
+        <h1 className="text-4xl font-bold text-white mb-2">Welcome, {userName}!</h1>
+        <p className="text-text-muted text-lg">Here's an overview of your expert activity and contributions.</p>
       </div>
 
       {/* KPI Cards */}
@@ -118,13 +118,13 @@ export default function Dashboard() {
         {kpiCards.map((kpi, index) => {
           const IconComponent = kpi.icon;
           return (
-            <Card key={index} className="bg-white border-gray-200 hover:border-gray-300 transition-colors shadow-sm rounded-xl">
+            <Card key={index} className="bg-card-dark border-border-dark transition-colors shadow-sm rounded-xl">
               <CardContent className="p-6">
                 <div className="flex items-center justify-between">
                   <div className="flex-1">
-                    <p className="text-sm text-gray-600 mb-1">{kpi.title}</p>
-                    <p className="text-2xl font-bold text-gray-900 mb-1">{kpi.value}</p>
-                    <p className="text-sm text-gray-600">{kpi.subtitle}</p>
+                    <p className="text-sm text-text-muted mb-1">{kpi.title}</p>
+                    <p className="text-2xl font-bold text-white mb-1">{kpi.value}</p>
+                    <p className="text-sm text-text-muted">{kpi.subtitle}</p>
                   </div>
                   <IconComponent className={`h-8 w-8 ${kpi.color} flex-shrink-0 ml-4`} />
                 </div>
@@ -135,9 +135,9 @@ export default function Dashboard() {
       </div>
 
       {/* Quick Actions */}
-      <Card className="bg-white border-gray-200 mb-8 shadow-sm rounded-xl">
+      <Card className="bg-card-dark border-border-dark mb-8 shadow-sm rounded-xl">
         <CardHeader>
-          <CardTitle className="text-gray-900 flex items-center">
+          <CardTitle className="text-white flex items-center">
             <div className="w-2 h-8 bg-primary rounded-full mr-3"></div>
             Quick Actions
           </CardTitle>
@@ -152,10 +152,10 @@ export default function Dashboard() {
               <Plus className="mr-2 h-4 w-4" />
               Contribute New Knowledge
             </Button>
-            <Button 
+            <Button
               onClick={handleReviewFeedback}
               variant="outline"
-              className="border-gray-200 text-gray-900 hover:bg-gray-50"
+              className="border-border-dark text-white hover:bg-bg-dark"
               data-testid="quick-action-review"
             >
               <FileText className="mr-2 h-4 w-4" />
@@ -166,9 +166,9 @@ export default function Dashboard() {
       </Card>
 
       {/* Recent Activity */}
-      <Card className="bg-white border-gray-200 shadow-sm rounded-xl">
+      <Card className="bg-card-dark border-border-dark shadow-sm rounded-xl">
         <CardHeader>
-          <CardTitle className="text-gray-900 flex items-center">
+          <CardTitle className="text-white flex items-center">
             <div className="w-2 h-8 bg-accent rounded-full mr-3"></div>
             Recent Activity
           </CardTitle>
@@ -178,11 +178,11 @@ export default function Dashboard() {
             {recentActivity.map((activity, index) => {
               const IconComponent = activity.icon;
               return (
-                <div key={index} className="flex items-start space-x-4 p-3 rounded-lg hover:bg-gray-50 transition-colors">
+                <div key={index} className="flex items-start space-x-4 p-3 rounded-lg hover:bg-bg-dark transition-colors">
                   <IconComponent className={`h-5 w-5 ${activity.color} flex-shrink-0 mt-0.5`} />
                   <div className="flex-1 min-w-0">
-                    <p className="text-gray-900 text-sm">{activity.text}</p>
-                    <p className="text-gray-600 text-xs mt-1">{activity.time}</p>
+                    <p className="text-white text-sm">{activity.text}</p>
+                    <p className="text-text-muted text-xs mt-1">{activity.time}</p>
                   </div>
                 </div>
               );

--- a/client/src/pages/portal/portal-layout.tsx
+++ b/client/src/pages/portal/portal-layout.tsx
@@ -27,11 +27,11 @@ export default function PortalLayout({ children }: PortalLayoutProps) {
   }
 
   return (
-    <div className="min-h-screen bg-gray-50" data-testid="portal-layout">
+    <div className="min-h-screen bg-bg-dark text-white" data-testid="portal-layout">
       <PortalHeader />
       <div className="flex">
         <PortalSidebar />
-        <main className="flex-1 p-8 bg-gray-50">
+        <main className="flex-1 p-8 bg-bg-dark">
           {children}
         </main>
       </div>


### PR DESCRIPTION
## Summary
- Switch portal layout to dark background and white text
- Restyle portal header and sidebar with landing page palette
- Update dashboard cards and actions to dark theme

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_b_689b2e345018832fa42d5e3734a13fd1