### PR TITLE
fix: improve button visibility

### DIFF
--- a/client/src/pages/portal/contribute.tsx
+++ b/client/src/pages/portal/contribute.tsx
@@ -154,23 +154,23 @@ export default function Contribute() {
           ))}
 
           <div className="flex flex-wrap gap-4">
-            <Button 
+            <Button
               onClick={addQAPair}
               variant="outline"
-              className="border-border-dark text-white hover:bg-gray-800"
+              className="bg-card-dark border-border-dark text-white hover:bg-gray-800 hover:text-white"
             >
               <Plus className="mr-2 h-4 w-4" />
               Add Another Q&A
             </Button>
-            <Button 
+            <Button
               onClick={handleFileUpload}
               variant="outline"
-              className="border-border-dark text-white hover:bg-gray-800"
+              className="bg-card-dark border-border-dark text-white hover:bg-gray-800 hover:text-white"
             >
               <Upload className="mr-2 h-4 w-4" />
               Upload Bulk Q&A (CSV/JSON)
             </Button>
-            <Button 
+            <Button
               onClick={submitQAPairs}
               className="bg-primary hover:bg-primary-hover"
             >

--- a/client/src/pages/portal/dashboard.tsx
+++ b/client/src/pages/portal/dashboard.tsx
@@ -155,7 +155,7 @@ export default function Dashboard() {
             <Button
               onClick={handleReviewFeedback}
               variant="outline"
-              className="border-border-dark text-white hover:bg-bg-dark"
+              className="bg-card-dark border-border-dark text-white hover:bg-bg-dark hover:text-white"
               data-testid="quick-action-review"
             >
               <FileText className="mr-2 h-4 w-4" />

--- a/client/src/pages/portal/support.tsx
+++ b/client/src/pages/portal/support.tsx
@@ -51,10 +51,10 @@ export default function Support() {
             <MessageCircle className="h-8 w-8 text-accent mx-auto mb-3" />
             <h3 className="font-medium text-white mb-2">Live Chat</h3>
             <p className="text-text-muted text-sm mb-3">Real-time assistance</p>
-            <Button 
-              variant="outline" 
+            <Button
+              variant="outline"
               size="sm"
-              className="border-border-dark text-white hover:bg-gray-800"
+              className="bg-card-dark border-border-dark text-white hover:bg-gray-800 hover:text-white"
               onClick={() => toast({ title: "Chat", description: "Live chat feature coming soon" })}
             >
               Start Chat


### PR DESCRIPTION
## Summary
- ensure outline buttons display on dark theme: review feedback, add Q&A, upload Q&A, and start chat

## Testing
- `npm test` (fails: Missing script "test")
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_b_689c47047778832fb0da4c8748c67101